### PR TITLE
questionをDBに保存する処理の実装

### DIFF
--- a/app/Http/Controllers/QuestionsController.php
+++ b/app/Http/Controllers/QuestionsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\AskQuestionRequest;
 use App\Question;
 use Illuminate\Http\Request;
 
@@ -37,9 +38,9 @@ class QuestionsController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(AskQuestionRequest $request)
     {
-        //
+        dd('store');
     }
 
     /**

--- a/app/Http/Controllers/QuestionsController.php
+++ b/app/Http/Controllers/QuestionsController.php
@@ -40,7 +40,9 @@ class QuestionsController extends Controller
      */
     public function store(AskQuestionRequest $request)
     {
-        dd('store');
+        $request->user()->questions()->create($request->only('title', 'body'));
+
+        return redirect()->route('questions.index')->with('success', 'Your question has been submitted');
     }
 
     /**

--- a/app/Http/Requests/AskQuestionRequest.php
+++ b/app/Http/Requests/AskQuestionRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AskQuestionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|max:255',
+            'body' => 'required',
+        ];
+    }
+}

--- a/resources/views/layouts/_messages.blade.php
+++ b/resources/views/layouts/_messages.blade.php
@@ -1,0 +1,8 @@
+@if (session('success'))
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <strong>Success!!</strong> {{ session('success') }}
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+@endif

--- a/resources/views/questions/create.blade.php
+++ b/resources/views/questions/create.blade.php
@@ -18,7 +18,7 @@
                             @csrf
                             <div class="form-group">
                                 <label for="question-title">Question Title</label>
-                                <input type="text" name="title" id="question-title" class="form-control {{ $errors->has('title') ? 'is-invalid' : '' }}" />
+                                <input type="text" name="title" id="question-title" value="{{ old('title') }}" class="form-control {{ $errors->has('title') ? 'is-invalid' : '' }}" />
                                 @if ($errors->has('title'))
                                     <div class="invalid-feedback">
                                         <strong>{{ $errors->first('title') }}</strong>
@@ -27,7 +27,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="question-body">Explain you question</label>
-                                <textarea type="body" name="body" id="question-body" rows="10" class="form-control {{ $errors->has('body') ? 'is-invalid' : '' }}"></textarea>
+                                <textarea type="body" name="body" id="question-body" rows="10" class="form-control {{ $errors->has('body') ? 'is-invalid' : '' }}">{{ old('body') }}</textarea>
                                 @if ($errors->has('body'))
                                     <div class="invalid-feedback">
                                         <strong>{{ $errors->first('body') }}</strong>

--- a/resources/views/questions/index.blade.php
+++ b/resources/views/questions/index.blade.php
@@ -14,6 +14,7 @@
                         </div>
                     </div>
                     <div class="card-body">
+                        @include('layouts._messages')
                         @foreach ($questions as $question)
                             <div class="media">
                                 <div class="d-flex flex-column counters">


### PR DESCRIPTION
## 概要
前回のPRでquestions.createページでquestionを作成するところまで作成した。
今回は作成したデータをDBに保存するまでの処理を実装したい。

## 要件
・DBに保存する上で各の項目のバリデーションは以下とする。
`title` : 必須、最大255バイト
`body` : 必須
・questionのDB保存に成功したらquestions.indexページにリダイレクトさせる。
その際にquestionの保存に成功した主旨のメッセージを表示する。

## TODO
- [x] バリデーションルールの実装
- [x] DB保存処理の実装
- [x] DB保存成功時のメッセージ表示の実装

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

