### PR TITLE
questionの編集機能の実装

### DIFF
--- a/app/Http/Controllers/QuestionsController.php
+++ b/app/Http/Controllers/QuestionsController.php
@@ -64,7 +64,7 @@ class QuestionsController extends Controller
      */
     public function edit(Question $question)
     {
-        //
+        return view('questions.edit', compact('question'));
     }
 
     /**

--- a/app/Http/Controllers/QuestionsController.php
+++ b/app/Http/Controllers/QuestionsController.php
@@ -74,9 +74,11 @@ class QuestionsController extends Controller
      * @param  \App\Question  $question
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, Question $question)
+    public function update(AskQuestionRequest $request, Question $question)
     {
-        //
+        $question->update($request->only('title', 'body'));
+
+        return redirect('/questions')->with('success', 'Your question has been updated');
     }
 
     /**

--- a/resources/views/questions/_form.blade.php
+++ b/resources/views/questions/_form.blade.php
@@ -1,0 +1,22 @@
+@csrf
+<div class="form-group">
+    <label for="question-title">Question Title</label>
+    <input type="text" name="title" id="question-title" value="{{ old('title') }}" class="form-control {{ $errors->has('title') ? 'is-invalid' : '' }}" />
+    @if ($errors->has('title'))
+        <div class="invalid-feedback">
+            <strong>{{ $errors->first('title') }}</strong>
+        </div>
+    @endif
+</div>
+<div class="form-group">
+    <label for="question-body">Explain you question</label>
+    <textarea type="body" name="body" id="question-body" rows="10" class="form-control {{ $errors->has('body') ? 'is-invalid' : '' }}">{{ old('body') }} </textarea>
+    @if ($errors->has('body'))
+        <div class="invalid-feedback">
+            <strong>{{ $errors->first('body') }}</strong>
+        </div>
+    @endif
+</div>
+<div class="form-group">
+    <button type="submit" class="btn btn-outline-primary btn-lg">{{ $buttonText }}</button>
+</div>

--- a/resources/views/questions/_form.blade.php
+++ b/resources/views/questions/_form.blade.php
@@ -1,7 +1,7 @@
 @csrf
 <div class="form-group">
     <label for="question-title">Question Title</label>
-    <input type="text" name="title" id="question-title" value="{{ old('title') }}" class="form-control {{ $errors->has('title') ? 'is-invalid' : '' }}" />
+    <input type="text" name="title" id="question-title" value="{{ old('title', $question->title) }}" class="form-control {{ $errors->has('title') ? 'is-invalid' : '' }}" />
     @if ($errors->has('title'))
         <div class="invalid-feedback">
             <strong>{{ $errors->first('title') }}</strong>
@@ -10,7 +10,7 @@
 </div>
 <div class="form-group">
     <label for="question-body">Explain you question</label>
-    <textarea type="body" name="body" id="question-body" rows="10" class="form-control {{ $errors->has('body') ? 'is-invalid' : '' }}">{{ old('body') }} </textarea>
+    <textarea type="body" name="body" id="question-body" rows="10" class="form-control {{ $errors->has('body') ? 'is-invalid' : '' }}">{{ old('body', $question->body) }} </textarea>
     @if ($errors->has('body'))
         <div class="invalid-feedback">
             <strong>{{ $errors->first('body') }}</strong>

--- a/resources/views/questions/create.blade.php
+++ b/resources/views/questions/create.blade.php
@@ -15,30 +15,8 @@
                     </div>
                     <div class="card-body">
                         <form action="{{ route('questions.store') }}" method="post">
-                            @csrf
-                            <div class="form-group">
-                                <label for="question-title">Question Title</label>
-                                <input type="text" name="title" id="question-title" value="{{ old('title') }}" class="form-control {{ $errors->has('title') ? 'is-invalid' : '' }}" />
-                                @if ($errors->has('title'))
-                                    <div class="invalid-feedback">
-                                        <strong>{{ $errors->first('title') }}</strong>
-                                    </div>
-                                @endif
-                            </div>
-                            <div class="form-group">
-                                <label for="question-body">Explain you question</label>
-                                <textarea type="body" name="body" id="question-body" rows="10" class="form-control {{ $errors->has('body') ? 'is-invalid' : '' }}">{{ old('body') }}</textarea>
-                                @if ($errors->has('body'))
-                                    <div class="invalid-feedback">
-                                        <strong>{{ $errors->first('body') }}</strong>
-                                    </div>
-                                @endif
-                            </div>
-                            <div class="form-group">
-                                <button type="submit" class="btn btn-outline-primary btn-lg">Ask This Question</button>
-                            </div>
+                            @include('questions._form', ['buttonText' => 'Ask Question'])
                         </form>
-
                     </div>
                 </div>
             </div>

--- a/resources/views/questions/edit.blade.php
+++ b/resources/views/questions/edit.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-header">
+                        <div class="d-flex align-items-center">
+                            <h2>Edit Questions</h2>
+                            <div class="ml-auto">
+                                <a href="{{ route('questions.index') }}" class="btn btn-outline-secondary">Back to All Question</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('questions.update', $question->id) }}" method="post">
+                            {{ method_field('PUT') }}
+                            @include('questions._form', ['buttonText' => 'Update Question'])
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/questions/index.blade.php
+++ b/resources/views/questions/index.blade.php
@@ -29,7 +29,12 @@
                                     </div>
                                 </div>
                                 <div class="media-body">
-                                    <h3 class="mt-0"><a href="{{ $question->url }}">{{ $question->title }}</a></h3>
+                                    <div class="d-flex align-items-center">
+                                        <h3 class="mt-0"><a href="{{ $question->url }}">{{ $question->title }}</a></h3>
+                                        <div class="ml-auto">
+                                            <a href="{{ route('questions.edit', $question->id) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                                        </div>
+                                    </div>
                                     <p class="lead">
                                         Asked by
                                         <a href="{{ $question->user->url }}">{{ $question->user->name }}</a>


### PR DESCRIPTION
## 概要
DBに保存されたquestionを編集する機能を実装する。

## 要件
・`questions.createページ` と `questions.editページ` での重複箇所を共通化させる。
・DBに保存する上で各項目のバリデーションは以下とする。
`title` : 必須、最大255バイト
`body` : 必須
・questionのDB保存に成功したらquestions.indexページにリダイレクトさせる。
その際にquestionの編集に成功した主旨のメッセージを表示する。

## TODO
- [x] バリデーションルールの実装
- [x] DB保存処理の実装
- [x] DB保存成功時のメッセージ表示の実装

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

