### PR TITLE
questionの削除処理実装

### DIFF
--- a/app/Http/Controllers/QuestionsController.php
+++ b/app/Http/Controllers/QuestionsController.php
@@ -89,6 +89,8 @@ class QuestionsController extends Controller
      */
     public function destroy(Question $question)
     {
-        //
-    }
+        $question->delete();
+
+        return redirect('/questions')->with('success', 'Your question has been deleted');
+}
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10963,3 +10963,7 @@ a.text-dark:focus {
   margin-top: 10px;
 }
 
+form.form-delete {
+  display: inline;
+}
+

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -38,3 +38,7 @@
         margin-top: 10px;
     }
 }
+
+form.form-delete {
+    display: inline;
+}

--- a/resources/views/questions/index.blade.php
+++ b/resources/views/questions/index.blade.php
@@ -33,6 +33,11 @@
                                         <h3 class="mt-0"><a href="{{ $question->url }}">{{ $question->title }}</a></h3>
                                         <div class="ml-auto">
                                             <a href="{{ route('questions.edit', $question->id) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                                            <form class="form-delete" action="{{ route('questions.destroy', $question->id) }}" method="post">
+                                                @method('DELETE')
+                                                @csrf
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure?')">Delete</button>
+                                            </form>
                                         </div>
                                     </div>
                                     <p class="lead">


### PR DESCRIPTION
## 概要
deleteボタンを押下後にquestionを削除できるようにしたい。

## 要件
questions.indexページから削除したいquestionのDeleteボタンを押下することで削除される。
削除後はquestion.indexページにリダイレクトされ、削除が成功した趣旨のメッセージを出力する。

## TODO
- [x] QuestionsController@destroyの実装
- [x] questions.indexページにdeleteボタンを表示

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

