### PR TITLE
question詳細ページの実装

### DIFF
--- a/app/Http/Controllers/QuestionsController.php
+++ b/app/Http/Controllers/QuestionsController.php
@@ -53,7 +53,10 @@ class QuestionsController extends Controller
      */
     public function show(Question $question)
     {
-        //
+        // 閲覧数を1たして保存
+        $question->increment('views');
+
+        return view('questions.show', compact('question'));
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Question;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
 
@@ -30,7 +31,9 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Route::bind('slug', function($slug) {
+            return Question::where('slug', $slug)->first() ?? abort(404);
+        });
 
         parent::boot();
     }

--- a/app/Question.php
+++ b/app/Question.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Parsedown;
 
 class Question extends Model
 {
@@ -37,7 +38,7 @@ class Question extends Model
      */
     public function getUrlAttribute()
     {
-        return route('questions.show', $this->id);
+        return route('questions.show', $this->slug);
     }
 
     /**
@@ -64,5 +65,10 @@ class Question extends Model
             return 'answered';
         }
         return 'unanswered';
+    }
+
+    public function getBodyHtmlAttribute()
+    {
+        return Parsedown::instance()->text($this->body);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0",
-        "laravel/ui": "^2.0"
+        "laravel/ui": "^2.0",
+        "parsedown/laravel": "^1.2"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6afecf1095fb595febed1d29529ecf68",
+    "content-hash": "d6e40b174db115c747d776b75ff7aef4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -421,6 +421,52 @@
                 "validator"
             ],
             "time": "2020-02-13T22:36:52+00:00"
+        },
+        {
+            "name": "erusev/parsedown",
+            "version": "1.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2019-12-30T22:54:17+00:00"
         },
         {
             "name": "fideloper/proxy",
@@ -1490,6 +1536,63 @@
                 "serialize"
             ],
             "time": "2020-05-25T09:32:45+00:00"
+        },
+        {
+            "name": "parsedown/laravel",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/parsedown/laravel.git",
+                "reference": "c713ffe28c76730754389180e86e93e8e84087e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/parsedown/laravel/zipball/c713ffe28c76730754389180e86e93e8e84087e7",
+                "reference": "c713ffe28c76730754389180e86e93e8e84087e7",
+                "shasum": ""
+            },
+            "require": {
+                "erusev/parsedown": "^1.7",
+                "php": ">=7.1.3"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^3.8",
+                "php": ">=7.2",
+                "phpunit/phpunit": "^8.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Parsedown\\Providers\\ParsedownServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "Parsedown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Agostini",
+                    "email": "edu.agostini@gmail.com"
+                }
+            ],
+            "description": "Official Parsedown's Laravel Wrapper.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "laravel",
+                "parsedown"
+            ],
+            "time": "2020-01-07T02:12:55+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-header">
+                        <div class="d-flex align-items-center">
+                            <h1>{{ $question->title }}</h1>
+                            <div class="ml-auto">
+                                <a href="{{ route('questions.index') }}" class="btn btn-outline-secondary">Back to All Question</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        {!! $question->body_html !!}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,4 +21,5 @@ Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
 
-Route::resource('questions', 'QuestionsController');
+Route::resource('questions', 'QuestionsController')->except('show');
+Route::get('/questions/{slug}', 'QuestionsController@show')->name('questions.show');


### PR DESCRIPTION
## 概要
questionの詳細ページを実装したい。

## 要件
・questions.indexページでquestionのタイトルを押下すると、questions.showページに遷移して、questionの`title`と`body`が表示される。
・questions.showページに遷移する際に、URLはidではなくslugで表示される。
・questions.showページの`body`はHTMLタグが変換されて出力される。
・questions.showページにアクセスすると、閲覧数として、questions.viewが1加算される。

## TODO
- [x] アクセサーを定義してslug表示にする
- [x] questions.showのルーティングを定義する
- [x] questions.showページのビューを作成する
- [x] `parsedown/laravel`を導入する

## 必要な情報

## 参考リンク

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

