### PR TITLE
Questionリソースに認可・認証機能を実装する

### DIFF
--- a/app/Http/Controllers/QuestionsController.php
+++ b/app/Http/Controllers/QuestionsController.php
@@ -8,6 +8,11 @@ use Illuminate\Http\Request;
 
 class QuestionsController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth', ['except' => ['index', 'show']]);
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -67,6 +72,7 @@ class QuestionsController extends Controller
      */
     public function edit(Question $question)
     {
+        $this->authorize('update', $question);
         return view('questions.edit', compact('question'));
     }
 
@@ -79,6 +85,7 @@ class QuestionsController extends Controller
      */
     public function update(AskQuestionRequest $request, Question $question)
     {
+        $this->authorize('update', $question);
         $question->update($request->only('title', 'body'));
 
         return redirect('/questions')->with('success', 'Your question has been updated');
@@ -92,6 +99,7 @@ class QuestionsController extends Controller
      */
     public function destroy(Question $question)
     {
+        $this->authorize('delete', $question);
         $question->delete();
 
         return redirect('/questions')->with('success', 'Your question has been deleted');

--- a/app/Policies/QuestionPolicy.php
+++ b/app/Policies/QuestionPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Question;
+use App\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class QuestionPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Question  $question
+     * @return mixed
+     */
+    public function update(User $user, Question $question)
+    {
+        return $user->id === $question->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Question  $question
+     * @return mixed
+     */
+    public function delete(User $user, Question $question)
+    {
+        return $user->id === $question->user_id && $question->answers < 1;
+    }
+
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Policies\QuestionPolicy;
+use App\Question;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
@@ -13,7 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Model' => 'App\Policies\ModelPolicy',
+        Question::class => QuestionPolicy::class,
     ];
 
     /**

--- a/resources/views/questions/index.blade.php
+++ b/resources/views/questions/index.blade.php
@@ -32,12 +32,16 @@
                                     <div class="d-flex align-items-center">
                                         <h3 class="mt-0"><a href="{{ $question->url }}">{{ $question->title }}</a></h3>
                                         <div class="ml-auto">
-                                            <a href="{{ route('questions.edit', $question->id) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                                            @can ('update', $question)
+                                                <a href="{{ route('questions.edit', $question->id) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                                            @endcan
+                                            @can ('delete', $question)
                                             <form class="form-delete" action="{{ route('questions.destroy', $question->id) }}" method="post">
                                                 @method('DELETE')
                                                 @csrf
                                                 <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure?')">Delete</button>
                                             </form>
+                                            @endcan
                                         </div>
                                     </div>
                                     <p class="lead">


### PR DESCRIPTION
## 概要
現状の仕様だと、自分が作成したQuestion以外でも編集・削除ができてしまう。
また、未ログイン状態でもquestion.createページに画面遷移できてしまう。
そのためQuestionリソースに認可・認証機能を実装したい。

## 要件
・自分の作成したQuestionのみ編集することができる。自分の以外のQuestionだと編集ボタンが表示されない。
・自分の作成したQuestionのみ削除することができる。自分の以外のQuestionだと削除ボタンが表示されない。
・未ログイン状態のまま `questions.createページ` に画面遷移すると、ログインページにリダイレクトされる。（ログイン後はquestions.createページに画面遷移される。）

## TODO
- [x] QuestionPolicyを定義する
- [x] QuestionsControllerの__construct()でauth()認証を設ける
- [x] 編集ボタン、削除ボタン表示の条件文を追加する

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

