### PR TITLE
answersテーブルのseeder作成

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -35,4 +35,17 @@ class Answer extends Model
     {
         return Parsedown::instance()->text($this->body);
     }
+
+    /**
+     * answerが作成された時に発火するイベント
+     * questions.answers_countカラムに1足す
+     */
+    public static function boot()
+    {
+        parent::boot();
+
+        static::created(function ($answer) {
+            $answer->question->increment('answers_count');
+        });
+    }
 }

--- a/database/factories/AnswerFactry.php
+++ b/database/factories/AnswerFactry.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Answer;
+use App\User;
+use Faker\Generator as Faker;
+
+$factory->define(Answer::class, function (Faker $faker) {
+    return [
+        'body' => $faker->paragraphs(rand(3, 7), true),
+        'user_id' => User::pluck('id')->random(),
+        'votes_count' => rand(0, 5)
+    ];
+});

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -10,7 +10,6 @@ $factory->define(Question::class, function (Faker $faker) {
         'title' => rtrim($faker->sentence(rand(5, 10)), "."),
         'body' => $faker->paragraphs(rand(3, 7), true),
         'views' => rand(0, 10),
-        'answers_count' => rand(0, 10),
         'votes' => rand(-3, 10),
     ];
 });

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Answer;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -15,7 +16,10 @@ class DatabaseSeeder extends Seeder
               $user->questions()
                    ->saveMany(
                        factory(App\Question::class, 5)->make()
-                   );
+                   )
+                  ->each(function ($q) {
+                      $q->answers()->saveMany(factory(Answer::class, rand(1, 5))->make());
+                  });
         });
         ;
     }


### PR DESCRIPTION
## 概要
answersテーブルにでもデータを挿入するためのseederを作成したい。

## 要件
・answersテーブルに適当な数のレコードを挿入する
・answersテーブルにレコードが挿入された際にイベントを発火してquestions.answers_countが1たす。

## TODO
- [x] seederファイルの作成
- [x] answerモデルにイベントを追加

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

