### PR TITLE
question.showページに紐づくanswerを表示

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Parsedown;
 
 class Answer extends Model
 {
@@ -47,5 +48,15 @@ class Answer extends Model
         static::created(function ($answer) {
             $answer->question->increment('answers_count');
         });
+    }
+
+    /**
+     * created_atのフォーマットを変更して取得(ex: 1 hour ago, 2 days ago)
+     *
+     * @return mixed 作成日時
+     */
+    public function getCreatedDateAttribute()
+    {
+        return $this->created_at->diffForHumans();
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -32,7 +32,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot()
     {
         Route::bind('slug', function($slug) {
-            return Question::where('slug', $slug)->first() ?? abort(404);
+            return Question::with('answers.user')->where('slug', $slug)->first() ?? abort(404);
         });
 
         parent::boot();

--- a/app/User.php
+++ b/app/User.php
@@ -67,4 +67,16 @@ class User extends Authenticatable
     {
         return $this->hasMany(Answer::class);
     }
+
+    /**
+     * userにアバター画像を取得
+     */
+    public function getAvatarAttribute()
+    {
+        $email = $this->email;
+        $size = 32;
+
+        return $grav_url = "https://www.gravatar.com/avatar/" . md5( strtolower( trim( $email ) ) ) . "?s=" . $size;
+
+    }
 }

--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -15,6 +15,44 @@
                     </div>
                     <div class="card-body">
                         {!! $question->body_html !!}
+                        <div class="float-right">
+                            <span class="text-muted">Answered {{ $question->created_date }}</span>
+                            <div class="media mt-2">
+                                <a href="{{ $question->user->url }}" class="pr-2"><img src="{{ $question->user->avatar }}"></a>
+                                <div class="media-body mt-1">
+                                    <a href="{{ $question->user->url }}">{{ $question->user->name }}</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row mt-4">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="card-title">
+                            <h2>{{ $question->answers_count . ' ' . Str::plural('Answer', $question->answers_count) }}</h2>
+                        </div>
+                        <hr>
+                        @foreach ($question->answers as $answer)
+                            <div class="media">
+                                <div class="media-body">
+                                    {!! $answer->body_html !!}
+                                    <div class="float-right">
+                                        <span class="text-muted">Answered {{ $answer->created_date }}</span>
+                                        <div class="media mt-2">
+                                            <a href="{{ $answer->user->url }}" class="pr-2"><img src="{{ $answer->user->avatar }}"></a>
+                                            <div class="media-body mt-1">
+                                                <a href="{{ $answer->user->url }}">{{ $answer->user->name }}</a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <hr>
+                        @endforeach
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 概要
question.showページに紐づくanswerを表示したい。

## 要件
・個々のanswerには下記の項目が表示されること。
  1. answerの本文
  2. answerのユーザー名(ユーザー名はリンク形式)
  3. answerの作成時刻(diffForHumans形式で表示)
  4. answerのユーザーアイコンにgravatarを表示(アイコンはリンク形式)

## TODO
- [x] answer表示のビューページを作成する
- [x] answerに紐づくアイコンをアクセサーで定義

## 必要な情報
https://ja.gravatar.com/

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

