### PR TITLE
answer編集機能の実装

### DIFF
--- a/app/Http/Controllers/AnswersController.php
+++ b/app/Http/Controllers/AnswersController.php
@@ -30,9 +30,11 @@ class AnswersController extends Controller
      * @param  \App\Answer  $answer
      * @return \Illuminate\Http\Response
      */
-    public function edit(Answer $answer)
+    public function edit(Question $question, Answer $answer)
     {
-        //
+        $this->authorize('update', $answer);
+
+        return view('answers.edit', compact('question', 'answer'));
     }
 
     /**
@@ -42,9 +44,15 @@ class AnswersController extends Controller
      * @param  \App\Answer  $answer
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, Answer $answer)
+    public function update(Request $request, Question $question, Answer $answer)
     {
-        //
+        $this->authorize('update', $answer);
+
+        $answer->update($request->validate([
+            'body' => 'required',
+        ]));
+
+        return redirect()->route('questions.show', $question->slug)->with('success', 'Your answer has been updated successfully');
     }
 
     /**

--- a/app/Policies/AnswerPolicy.php
+++ b/app/Policies/AnswerPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Policies;
+
+use App\Answer;
+use App\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class AnswerPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Answer  $answer
+     * @return mixed
+     */
+    public function update(User $user, Answer $answer)
+    {
+        return $user->id === $answer->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Answer  $answer
+     * @return mixed
+     */
+    public function delete(User $user, Answer $answer)
+    {
+        return $user->id === $answer->user_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Answer;
+use App\Policies\AnswerPolicy;
 use App\Policies\QuestionPolicy;
 use App\Question;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
@@ -16,6 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Question::class => QuestionPolicy::class,
+        Answer::class => AnswerPolicy::class,
     ];
 
     /**

--- a/resources/views/answers/_index.blade.php
+++ b/resources/views/answers/_index.blade.php
@@ -23,15 +23,35 @@
                         </div>
                         <div class="media-body">
                             {!! $answer->body_html !!}
-                            <div class="float-right">
-                                <span class="text-muted">Answered {{ $answer->created_date }}</span>
-                                <div class="media mt-2">
-                                    <a href="{{ $answer->user->url }}" class="pr-2"><img src="{{ $answer->user->avatar }}"></a>
-                                    <div class="media-body mt-1">
-                                        <a href="{{ $answer->user->url }}">{{ $answer->user->name }}</a>
+                            <div class="row">
+                                <div class="col-4">
+                                    <div class="ml-auto">
+                                        @can ('update', $answer)
+                                            <a href="{{ route('answers.edit', [$question->id, $answer->id]) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                                        @endcan
+                                        @can ('delete', $answer)
+                                            <form class="form-delete" action="{{ route('answers.destroy', [$question->id, $answer->id]) }}" method="post">
+                                                @method('DELETE')
+                                                @csrf
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure?')">Delete</button>
+                                            </form>
+                                        @endcan
+                                    </div>
+                                </div>
+                                <div class="col-4">
+
+                                </div>
+                                <div class="col-4">
+                                    <span class="text-muted">Answered {{ $answer->created_date }}</span>
+                                    <div class="media mt-2">
+                                        <a href="{{ $answer->user->url }}" class="pr-2"><img src="{{ $answer->user->avatar }}"></a>
+                                        <div class="media-body mt-1">
+                                            <a href="{{ $answer->user->url }}">{{ $answer->user->name }}</a>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
+
                         </div>
                     </div>
                     <hr>

--- a/resources/views/answers/edit.blade.php
+++ b/resources/views/answers/edit.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row mt-4">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <div class="card-title">
+                        <h1>Editing answer for question:<strong>{{ $question->title }}</strong></h1>
+                    </div>
+                    <hr>
+                    <form action="{{ route('answers.update', [$question->id, $answer->id]) }}" method="post">
+                        @csrf
+                        @method('PATCH')
+                        <div class="form-group">
+                            <textarea name="body" class="form-control {{ $errors->has('body') ? 'is-invalid' : '' }}" cols="30" rows="7">{{ old('body', $answer->body) }}</textarea>
+                            @if ($errors->has('body'))
+                                <div class="invalid-feedback">
+                                    <strong>{{ $errors->first('body') }}</strong>
+                                </div>
+                            @endif
+                        </div>
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-lg btn-outline-primary">Update</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,6 @@ Route::get('/home', 'HomeController@index')->name('home');
 Route::resource('questions', 'QuestionsController')->except('show');
 Route::post('/questions/{question}/answers', 'AnswersController@store')->name('answers.store');
 Route::get('/questions/{question}/answers/{answer}/edit', 'AnswersController@edit')->name('answers.edit');
-Route::put('/questions/{question}/answers/{answer}', 'AnswersController@update')->name('answers.update');
+Route::patch('/questions/{question}/answers/{answer}', 'AnswersController@update')->name('answers.update');
 Route::delete('/questions/{question}/answers/{answer}', 'AnswersController@destroy')->name('answers.destroy');
 Route::get('/questions/{slug}', 'QuestionsController@show')->name('questions.show');


### PR DESCRIPTION
## 概要
answer編集機能の実装したい。

## 要件
・`question.showページ`でeditボタンを押下したら、`answer.editページ`に画面遷移する。
・`answer.editページ`でanswerを編集してupdateボタンを押下したら編集して保存される。
・編集後は編集完了した趣旨のメッセージと共に`question.showページ`にリダイレクトされる。
・編集できるanswerは自分が投稿したanswerのみとする。

## TODO
- [x] AnswersControlerの実装
- [x] answers.edit.blade.phpの作成
- [x] AnswerPolicyの作成

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

