### PR TITLE
answers削除処理の実装

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -41,14 +41,19 @@ class Answer extends Model
 
     /**
      * answerが作成された時に発火するイベント
-     * questions.answers_countカラムに1足す
      */
     public static function boot()
     {
         parent::boot();
 
+        // questionが作成された時、questions.answers_countカラムに1足す
         static::created(function ($answer) {
             $answer->question->increment('answers_count');
+        });
+
+        // questionが削除された時、questions.answers_countカラムから1引く
+        static::deleted(function ($answer) {
+           $answer->question->decrement('answers_count');
         });
     }
 

--- a/app/Http/Controllers/AnswersController.php
+++ b/app/Http/Controllers/AnswersController.php
@@ -61,8 +61,12 @@ class AnswersController extends Controller
      * @param  \App\Answer  $answer
      * @return \Illuminate\Http\Response
      */
-    public function destroy(Answer $answer)
+    public function destroy(Question $question, Answer $answer)
     {
-        //
+        $this->authorize('delete', $answer);
+
+        $answer->delete();
+
+        return back()->with('success', 'Your answer has been removed');
     }
 }


### PR DESCRIPTION
## 概要
answersを削除する処理を実装したい。

## 要件
・`questions.showページ`でDeleteボタンを押下した後にalertが表示されて該当のanswerが削除される。
・answer削除後は`question.showページ`メッセージ付きでリダイレクトされる。
・削除できるanswerは自分が投稿したanswerのみである。
・answerが削除された後に、`questions.answer_count`が1減る。

## TODO
- [x] AnswersController@delete()を実装する。
- [x] Answerモデルに`questions.answer_count`から1減らす処理を実装する。

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

