### PR TITLE
ベストアンサーが削除された時にquestions.best_answer_idカラムをアップデートする処理の実装

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -53,7 +53,13 @@ class Answer extends Model
 
         // questionが削除された時、questions.answers_countカラムから1引く
         static::deleted(function ($answer) {
-           $answer->question->decrement('answers_count');
+            $question = $answer->question;
+            $question->decrement('answers_count');
+            // ベストアンサーが削除された場合はquestion.best_answer_idをNULLにする
+            if ($question->best_answer_id === $answer->id) {
+                $question->best_answer_id = NULL;
+                $question->save();
+            }
         });
     }
 
@@ -65,5 +71,13 @@ class Answer extends Model
     public function getCreatedDateAttribute()
     {
         return $this->created_at->diffForHumans();
+    }
+
+    /**
+     * answerがベストアンサーに選出されていたら、vote-acceptedを返す
+     */
+    public function getStatusAttribute()
+    {
+        return $this->id === $this->question->best_answer_id ? 'vote-accepted' : '';
     }
 }

--- a/resources/views/answers/_index.blade.php
+++ b/resources/views/answers/_index.blade.php
@@ -17,10 +17,10 @@
                             <a title="This answer is not useful" class="vote-down off">
                                 <i class="fas fa-caret-down fa-3x"></i>
                             </a>
-                            <a title="Mark this answer as best answer" class="vote-accepted mt-3">
+                            <a title="Mark this answer as best answer" class="{{ $answer->status }} mt-3">
                                 <i class="fas fa-check fa-2x"></i>
                             </a>
-                        </div>
+                        </div>ls
                         <div class="media-body">
                             {!! $answer->body_html !!}
                             <div class="row">


### PR DESCRIPTION
## 概要
ベストアンサーが削除された際に、ベストアンサーはすでに存在しないのに、questions.best_answer_idカラムだけ削除されたanswer.idになっている障害があった。
そのため、ベストアンサーが削除された際にquestions.best_answer_idカラムをNULLに更新する処理を追加したい。

## 要件
・ベストアンサーが削除された際に、`questions.best_answer_id`をNULLにする。
・ベストアンサーに選出されているanswerは✔︎マークを緑色にする。

## TODO
- [x] answer削除する際に発火するイベントに処理を追加
- [x] ✔︎マークのclassにステータスを動的に挿入

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

