### PR TITLE
ベストアンサーが削除されたときのbest_answer_idカラムのアップデート処理

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -66,4 +66,12 @@ class Answer extends Model
     {
         return $this->created_at->diffForHumans();
     }
+
+    /**
+     * answerがベストアンサーに選出されていたら、vote-acceptedを返す
+     */
+    public function getStatusAttribute()
+    {
+        return $this->id === $this->question->best_answer_id ? 'vote-accepted' : '';
+    }
 }

--- a/database/migrations/2020_06_06_132902_create_questions_table.php
+++ b/database/migrations/2020_06_06_132902_create_questions_table.php
@@ -21,7 +21,7 @@ class CreateQuestionsTable extends Migration
             $table->unsignedInteger('views')->default(0);
             $table->unsignedInteger('answers')->default(0);
             $table->integer('votes')->default(0);
-            $table->unsignedInteger('best_answer_id')->nullable();
+            $table->unsignedBigInteger('best_answer_id')->nullable();
             $table->unsignedBigInteger('user_id');
             $table->timestamps();
 

--- a/database/migrations/2020_06_11_154642_add_foreign_best_answer_id_to_questions_table.php
+++ b/database/migrations/2020_06_11_154642_add_foreign_best_answer_id_to_questions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignBestAnswerIdToQuestionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->foreign('best_answer_id')
+                ->references('id')
+                ->on('answers')
+                ->onDelete('SET NULL');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropForeign(['best_answer_id']);
+        });
+    }
+}

--- a/resources/views/answers/_index.blade.php
+++ b/resources/views/answers/_index.blade.php
@@ -17,7 +17,7 @@
                             <a title="This answer is not useful" class="vote-down off">
                                 <i class="fas fa-caret-down fa-3x"></i>
                             </a>
-                            <a title="Mark this answer as best answer" class="vote-accepted mt-3">
+                            <a title="Mark this answer as best answer" class="{{ $answer->status }} mt-3">
                                 <i class="fas fa-check fa-2x"></i>
                             </a>
                         </div>


### PR DESCRIPTION
## 概要
ベストアンサーが削除された際に、ベストアンサーはすでに存在しないのに、questions.best_answer_idカラムだけ削除されたanswer.idになっている障害があった。
そのため、ベストアンサーが削除された際にquestions.best_answer_idカラムをNULLに更新する処理を追加したい。

## 要件
・ベストアンサーが削除された際に、`questions.best_answer_id`をNULLにする。
・ベストアンサーに選出されているanswerは✔︎マークを緑色にする。

## TODO
- [x] answer削除する際に発火するイベントに処理を追加
- [x] ✔︎マークのclassにステータスを動的に挿入

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

