### PR TITLE
questionとanswerを各投稿をpartialに分離

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -17067,3 +17067,11 @@ form.form-delete {
   color: #38c172;
 }
 
+.post {
+  padding: 20px 0;
+}
+
+.post:not(:last-child) {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -81,3 +81,10 @@ form.form-delete {
         }
     }
 }
+
+.post {
+    padding: 20px 0;
+    &:not(:last-child) {
+        border-bottom: 1px solid rgba($black, .1);
+    }
+}

--- a/resources/views/answers/_answer.blade.php
+++ b/resources/views/answers/_answer.blade.php
@@ -1,0 +1,34 @@
+<div class="media post">
+    @include ('shared._vote', [
+        'model' => $answer,
+    ])
+    <div class="media-body">
+        {!! $answer->body_html !!}
+        <div class="row">
+            <div class="col-4">
+                <div class="ml-auto">
+                    @can ('update', $answer)
+                        <a href="{{ route('answers.edit', [$question->id, $answer->id]) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                    @endcan
+                    @can ('delete', $answer)
+                        <form class="form-delete" action="{{ route('answers.destroy', [$question->id, $answer->id]) }}" method="post">
+                            @method('DELETE')
+                            @csrf
+                            <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure?')">Delete</button>
+                        </form>
+                    @endcan
+                </div>
+            </div>
+            <div class="col-4">
+
+            </div>
+            <div class="col-4">
+                @include ('shared._author', [
+                    'model' => $answer,
+                    'label' => 'answered',
+                ])
+            </div>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/answers/_index.blade.php
+++ b/resources/views/answers/_index.blade.php
@@ -9,41 +9,7 @@
                     <hr>
                     @include('layouts._messages')
                     @foreach ($answers as $answer)
-                        <div class="media">
-                            @include ('shared._vote', [
-                                'model' => $answer,
-                            ])
-                            <div class="media-body">
-                                {!! $answer->body_html !!}
-                                <div class="row">
-                                    <div class="col-4">
-                                        <div class="ml-auto">
-                                            @can ('update', $answer)
-                                                <a href="{{ route('answers.edit', [$question->id, $answer->id]) }}" class="btn btn-sm btn-outline-info">Edit</a>
-                                            @endcan
-                                            @can ('delete', $answer)
-                                                <form class="form-delete" action="{{ route('answers.destroy', [$question->id, $answer->id]) }}" method="post">
-                                                    @method('DELETE')
-                                                    @csrf
-                                                    <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure?')">Delete</button>
-                                                </form>
-                                            @endcan
-                                        </div>
-                                    </div>
-                                    <div class="col-4">
-
-                                    </div>
-                                    <div class="col-4">
-                                        @include ('shared._author', [
-                                            'model' => $answer,
-                                            'label' => 'answered',
-                                        ])
-                                    </div>
-                                </div>
-
-                            </div>
-                        </div>
-                        <hr>
+                        @include ('answers._answer', ['answer' => $answer])
                     @endforeach
                 </div>
             </div>

--- a/resources/views/questions/_excerpt.blade.php
+++ b/resources/views/questions/_excerpt.blade.php
@@ -1,0 +1,36 @@
+<div class="media post">
+    <div class="d-flex flex-column counters">
+        <div class="vote">
+            <strong>{{ $question->votes_count }}</strong>{{ Str::plural('vote', $question->votes_count ) }}
+        </div>
+        <div class="status {{ $question->status }}">
+            <strong>{{ $question->answers_count }}</strong>{{ Str::plural('answer', $question->answers_count ) }}
+        </div>
+        <div class="view">
+            {{ $question->views . " " . Str::plural('view', $question->views) }}
+        </div>
+    </div>
+    <div class="media-body">
+        <div class="d-flex align-items-center">
+            <h3 class="mt-0"><a href="{{ $question->url }}">{{ $question->title }}</a></h3>
+            <div class="ml-auto">
+                @can ('update', $question)
+                    <a href="{{ route('questions.edit', $question->id) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                @endcan
+                @can ('delete', $question)
+                    <form class="form-delete" action="{{ route('questions.destroy', $question->id) }}" method="post">
+                        @method('DELETE')
+                        @csrf
+                        <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure?')">Delete</button>
+                    </form>
+                @endcan
+            </div>
+        </div>
+        <p class="lead">
+            Asked by
+            <a href="{{ $question->user->url }}">{{ $question->user->name }}</a>
+            <small class="text-muted">{{ $question->created_date }}</small>
+        </p>
+        <div class="excerpt">{{ $question->excerpt }}</div>
+    </div>
+</div>

--- a/resources/views/questions/index.blade.php
+++ b/resources/views/questions/index.blade.php
@@ -16,52 +16,16 @@
                     <div class="card-body">
                         @include('layouts._messages')
                         @forelse ($questions as $question)
-                            <div class="media">
-                                <div class="d-flex flex-column counters">
-                                    <div class="vote">
-                                        <strong>{{ $question->votes_count }}</strong>{{ Str::plural('vote', $question->votes_count ) }}
-                                    </div>
-                                    <div class="status {{ $question->status }}">
-                                        <strong>{{ $question->answers_count }}</strong>{{ Str::plural('answer', $question->answers_count ) }}
-                                    </div>
-                                    <div class="view">
-                                        {{ $question->views . " " . Str::plural('view', $question->views) }}
-                                    </div>
-                                </div>
-                                <div class="media-body">
-                                    <div class="d-flex align-items-center">
-                                        <h3 class="mt-0"><a href="{{ $question->url }}">{{ $question->title }}</a></h3>
-                                        <div class="ml-auto">
-                                            @can ('update', $question)
-                                                <a href="{{ route('questions.edit', $question->id) }}" class="btn btn-sm btn-outline-info">Edit</a>
-                                            @endcan
-                                            @can ('delete', $question)
-                                            <form class="form-delete" action="{{ route('questions.destroy', $question->id) }}" method="post">
-                                                @method('DELETE')
-                                                @csrf
-                                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure?')">Delete</button>
-                                            </form>
-                                            @endcan
-                                        </div>
-                                    </div>
-                                    <p class="lead">
-                                        Asked by
-                                        <a href="{{ $question->user->url }}">{{ $question->user->name }}</a>
-                                        <small class="text-muted">{{ $question->created_date }}</small>
-                                    </p>
-                                    <div class="excerpt">{{ $question->excerpt }}</div>
-                                </div>
-                            </div>
-                            <hr>
+                            @include ('questions._excerpt')
                         @empty
                             <div class="alert alert-warning">
                                 <strong>Sorry</strong>There are no questions available.
                             </div>
                         @endforelse
-                        <div class="text-center">
-                            {{ $questions->links() }}
-                        </div>
                     </div>
+                </div>
+                <div class="pt-3">
+                    {{ $questions->links() }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## 概要
questionとanswerがそれぞれ1つのページにコーディングされているので、それぞれの投稿をpartialに分離したい。

## 要件
・foreach内の要素を`partial`に分離する
・最後の要素には`border-bottom`を付けない

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

