### PR TITLE
Answerの削除処理をVue.jsでリプレイス

### DIFF
--- a/app/Http/Controllers/AnswersController.php
+++ b/app/Http/Controllers/AnswersController.php
@@ -53,10 +53,10 @@ class AnswersController extends Controller
         ]));
 
         if ($request->expectsJson()) {
-        return response()->json([
-            'message' => 'Your answer has been updated successfully',
-            'body_html' => $answer->body_html
-        ]);
+            return response()->json([
+                'message' => 'Your answer has been updated successfully',
+                'body_html' => $answer->body_html
+            ]);
         }
 
         return redirect()->route('questions.show', $question->slug)->with('success', 'Your answer has been updated successfully');
@@ -73,6 +73,12 @@ class AnswersController extends Controller
         $this->authorize('delete', $answer);
 
         $answer->delete();
+
+        if (request()->expectsJson()) {
+            return response()->json([
+                'message' => 'Your answer has been removed',
+            ]);
+        }
 
         return back()->with('success', 'Your answer has been removed');
     }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1932,7 +1932,7 @@ __webpack_require__.r(__webpack_exports__);
     update: function update() {
       var _this = this;
 
-      axios.patch("/questions/".concat(this.questionId, "/answers/").concat(this.id), {
+      axios.patch(this.endpoint, {
         body: this.body
       }).then(function (res) {
         _this.editing = false;
@@ -1941,11 +1941,25 @@ __webpack_require__.r(__webpack_exports__);
       })["catch"](function (err) {
         alert(err.response.data.message);
       });
+    },
+    destroy: function destroy() {
+      var _this2 = this;
+
+      if (confirm('Are you sure?')) {
+        axios["delete"](this.endpoint).then(function (res) {
+          $(_this2.$el).fadeOut(500, function () {
+            alert(res.data.message);
+          });
+        });
+      }
     }
   },
   computed: {
     isInvalid: function isInvalid() {
       return this.body.length < 10;
+    },
+    endpoint: function endpoint() {
+      return "/questions/".concat(this.questionId, "/answers/").concat(this.id);
     }
   }
 });

--- a/resources/js/components/Answer.vue
+++ b/resources/js/components/Answer.vue
@@ -25,7 +25,7 @@
             },
 
             update () {
-                axios.patch(`/questions/${this.questionId}/answers/${this.id}`, {
+                axios.patch(this.endpoint, {
                     body: this.body,
                 })
                 .then(res => {
@@ -36,12 +36,27 @@
                 .catch(err => {
                     alert(err.response.data.message);
                 });
+            },
+
+            destroy () {
+                if (confirm('Are you sure?')) {
+                    axios.delete(this.endpoint)
+                    .then(res => {
+                        $(this.$el).fadeOut(500, () => {
+                            alert(res.data.message);
+                        })
+                    });
+                }
             }
         },
 
         computed: {
             isInvalid () {
                 return this.body.length < 10;
+            },
+
+            endpoint () {
+                return `/questions/${this.questionId}/answers/${this.id}`;
             }
         },
     }

--- a/resources/views/answers/_answer.blade.php
+++ b/resources/views/answers/_answer.blade.php
@@ -20,11 +20,7 @@
                                 <a @click.prevent="edit" class="btn btn-sm btn-outline-info">Edit</a>
                             @endcan
                             @can ('delete', $answer)
-                                <form class="form-delete" action="{{ route('answers.destroy', [$question->id, $answer->id]) }}" method="post">
-                                    @method('DELETE')
-                                    @csrf
-                                    <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure?')">Delete</button>
-                                </form>
+                                <button @click="destroy" class="btn btn-sm btn-outline-danger">Delete</button>
                             @endcan
                         </div>
                     </div>


### PR DESCRIPTION
## 概要
Answerの削除処理をVue.jsでリプレイス

## 要件
・`Delete`ボタンを押下したら、confirmのalertが表示されてOKを押下後に該当のanswerがajaxで削除される。

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

