### PR TITLE
favoriteパーツをVue.jsのfavoriteコンポーネントにリプレイス

### DIFF
--- a/app/Http/Controllers/FavoritesController.php
+++ b/app/Http/Controllers/FavoritesController.php
@@ -23,6 +23,10 @@ class FavoritesController extends Controller
     {
         $question->favorites()->attach(Auth::id());
 
+        if (request()->expectsJson()) {
+            return response()->json(null, 204);
+        }
+
         return back();
     }
 
@@ -35,6 +39,10 @@ class FavoritesController extends Controller
     public function destroy(Question $question)
     {
         $question->favorites()->detach(Auth::id());
+
+        if (request()->expectsJson()) {
+            return response()->json(null, 204);
+        }
 
         return back();
     }

--- a/app/Question.php
+++ b/app/Question.php
@@ -23,7 +23,7 @@ class Question extends Model
      *
      * @var string[]
      */
-    protected $appends = ['created_date'];
+    protected $appends = ['created_date', 'is_favorited', 'favorites_count'];
 
     /**
      * ユーザーの取得

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2010,8 +2010,6 @@ __webpack_require__.r(__webpack_exports__);
     return {
       isFavorited: this.question.is_favorited,
       count: this.question.favorites_count,
-      signedIn: true,
-      // あとで修正する,
       id: this.question.id
     };
   },
@@ -2021,10 +2019,21 @@ __webpack_require__.r(__webpack_exports__);
     },
     endpoint: function endpoint() {
       return "/questions/".concat(this.id, "/favorites");
+    },
+    signedIn: function signedIn() {
+      return window.Auth.signedIn;
     }
   },
   methods: {
     toggle: function toggle() {
+      if (!this.signedIn) {
+        this.$toast.warning('Please login to favorite this question', 'Warning', {
+          timeout: 3000,
+          position: 'bottomLeft'
+        });
+        return;
+      }
+
       this.isFavorited ? this.destroy() : this.create();
     },
     destroy: function destroy() {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2010,13 +2010,38 @@ __webpack_require__.r(__webpack_exports__);
     return {
       isFavorited: this.question.is_favorited,
       count: this.question.favorites_count,
-      signedIn: true // あとで修正する
-
+      signedIn: true,
+      // あとで修正する,
+      id: this.question.id
     };
   },
   computed: {
     classes: function classes() {
       return ['favorite', 'mt-3', !this.signedIn ? 'off' : this.isFavorited ? 'favorited' : ''];
+    },
+    endpoint: function endpoint() {
+      return "/questions/".concat(this.id, "/favorites");
+    }
+  },
+  methods: {
+    toggle: function toggle() {
+      this.isFavorited ? this.destroy() : this.create();
+    },
+    destroy: function destroy() {
+      var _this = this;
+
+      axios["delete"](this.endpoint).then(function (res) {
+        _this.count--;
+        _this.isFavorited = false;
+      });
+    },
+    create: function create() {
+      var _this2 = this;
+
+      axios.post(this.endpoint).then(function (res) {
+        _this2.count++;
+        _this2.isFavorited = true;
+      });
     }
   }
 });
@@ -38314,6 +38339,12 @@ var render = function() {
       class: _vm.classes,
       attrs: {
         title: "Click to mark as favorite question (Click again to undo)"
+      },
+      on: {
+        click: function($event) {
+          $event.preventDefault()
+          return _vm.toggle($event)
+        }
       }
     },
     [

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1989,6 +1989,40 @@ __webpack_require__.r(__webpack_exports__);
 
 /***/ }),
 
+/***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Favorite.vue?vue&type=script&lang=js&":
+/*!*******************************************************************************************************************************************************************!*\
+  !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/Favorite.vue?vue&type=script&lang=js& ***!
+  \*******************************************************************************************************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+//
+//
+//
+//
+//
+//
+/* harmony default export */ __webpack_exports__["default"] = ({
+  props: ['question'],
+  data: function data() {
+    return {
+      isFavorited: this.question.is_favorited,
+      count: this.question.favorites_count,
+      signedIn: true // あとで修正する
+
+    };
+  },
+  computed: {
+    classes: function classes() {
+      return ['favorite', 'mt-3', !this.signedIn ? 'off' : this.isFavorited ? 'favorited' : ''];
+    }
+  }
+});
+
+/***/ }),
+
 /***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/UserInfo.vue?vue&type=script&lang=js&":
 /*!*******************************************************************************************************************************************************************!*\
   !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/UserInfo.vue?vue&type=script&lang=js& ***!
@@ -38259,6 +38293,45 @@ exports.clearImmediate = (typeof self !== "undefined" && self.clearImmediate) ||
 
 /***/ }),
 
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Favorite.vue?vue&type=template&id=3982b107&":
+/*!***********************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/Favorite.vue?vue&type=template&id=3982b107& ***!
+  \***********************************************************************************************************************************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "a",
+    {
+      class: _vm.classes,
+      attrs: {
+        title: "Click to mark as favorite question (Click again to undo)"
+      }
+    },
+    [
+      _c("i", { staticClass: "fas fa-star fa-2x" }),
+      _vm._v(" "),
+      _c("span", { staticClass: "favorites-count" }, [
+        _vm._v(_vm._s(_vm.count))
+      ])
+    ]
+  )
+}
+var staticRenderFns = []
+render._withStripped = true
+
+
+
+/***/ }),
+
 /***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/UserInfo.vue?vue&type=template&id=11f66ff8&":
 /*!***********************************************************************************************************************************************************************************************************!*\
   !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/UserInfo.vue?vue&type=template&id=11f66ff8& ***!
@@ -50498,6 +50571,7 @@ Vue.use(vue_izitoast__WEBPACK_IMPORTED_MODULE_0___default.a);
 
 Vue.component('user-info', __webpack_require__(/*! ./components/UserInfo.vue */ "./resources/js/components/UserInfo.vue")["default"]);
 Vue.component('answer', __webpack_require__(/*! ./components/Answer.vue */ "./resources/js/components/Answer.vue")["default"]);
+Vue.component('favorite', __webpack_require__(/*! ./components/Favorite.vue */ "./resources/js/components/Favorite.vue")["default"]);
 /**
  * Next, we will create a fresh Vue application instance and attach it to
  * the page. Then, you may begin adding components to this application
@@ -50602,6 +50676,75 @@ component.options.__file = "resources/js/components/Answer.vue"
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Answer_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib??ref--4-0!../../../node_modules/vue-loader/lib??vue-loader-options!./Answer.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Answer.vue?vue&type=script&lang=js&");
 /* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Answer_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
+
+/***/ }),
+
+/***/ "./resources/js/components/Favorite.vue":
+/*!**********************************************!*\
+  !*** ./resources/js/components/Favorite.vue ***!
+  \**********************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _Favorite_vue_vue_type_template_id_3982b107___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Favorite.vue?vue&type=template&id=3982b107& */ "./resources/js/components/Favorite.vue?vue&type=template&id=3982b107&");
+/* harmony import */ var _Favorite_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Favorite.vue?vue&type=script&lang=js& */ "./resources/js/components/Favorite.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+
+
+
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__["default"])(
+  _Favorite_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
+  _Favorite_vue_vue_type_template_id_3982b107___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _Favorite_vue_vue_type_template_id_3982b107___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "resources/js/components/Favorite.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/components/Favorite.vue?vue&type=script&lang=js&":
+/*!***********************************************************************!*\
+  !*** ./resources/js/components/Favorite.vue?vue&type=script&lang=js& ***!
+  \***********************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Favorite_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib??ref--4-0!../../../node_modules/vue-loader/lib??vue-loader-options!./Favorite.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Favorite.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Favorite_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
+
+/***/ }),
+
+/***/ "./resources/js/components/Favorite.vue?vue&type=template&id=3982b107&":
+/*!*****************************************************************************!*\
+  !*** ./resources/js/components/Favorite.vue?vue&type=template&id=3982b107& ***!
+  \*****************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Favorite_vue_vue_type_template_id_3982b107___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!../../../node_modules/vue-loader/lib??vue-loader-options!./Favorite.vue?vue&type=template&id=3982b107& */ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Favorite.vue?vue&type=template&id=3982b107&");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Favorite_vue_vue_type_template_id_3982b107___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Favorite_vue_vue_type_template_id_3982b107___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
 
 /***/ }),
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -27,6 +27,7 @@ Vue.use(VueIziToast);
 
 Vue.component('user-info', require('./components/UserInfo.vue').default);
 Vue.component('answer', require('./components/Answer.vue').default);
+Vue.component('favorite', require('./components/Favorite.vue').default);
 
 /**
  * Next, we will create a fresh Vue application instance and attach it to

--- a/resources/js/components/Favorite.vue
+++ b/resources/js/components/Favorite.vue
@@ -1,5 +1,5 @@
 <template>
-    <a title="Click to mark as favorite question (Click again to undo)" :class="classes">
+    <a title="Click to mark as favorite question (Click again to undo)" :class="classes" @click.prevent="toggle">
         <i class="fas fa-star fa-2x"></i>
         <span class="favorites-count">{{ count }}</span>
     </a>
@@ -12,7 +12,8 @@
             return {
                 isFavorited: this.question.is_favorited,
                 count: this.question.favorites_count,
-                signedIn: true, // あとで修正する
+                signedIn: true, // あとで修正する,
+                id: this.question.id,
             }
         },
 
@@ -22,7 +23,33 @@
                    'favorite', 'mt-3',
                     ! this.signedIn ? 'off' : (this.isFavorited ? 'favorited' : '')
                 ];
+            },
+
+            endpoint () {
+                return `/questions/${this.id}/favorites`
             }
+        },
+
+        methods: {
+            toggle () {
+                this.isFavorited ? this.destroy() : this.create();
+            },
+
+            destroy () {
+                axios.delete(this.endpoint)
+                .then(res => {
+                    this.count--;
+                    this.isFavorited = false;
+                });
+            },
+
+            create () {
+                axios.post(this.endpoint)
+                .then(res => {
+                    this.count++;
+                    this.isFavorited = true;
+                });
+            },
         }
     }
 </script>

--- a/resources/js/components/Favorite.vue
+++ b/resources/js/components/Favorite.vue
@@ -12,7 +12,6 @@
             return {
                 isFavorited: this.question.is_favorited,
                 count: this.question.favorites_count,
-                signedIn: true, // あとで修正する,
                 id: this.question.id,
             }
         },
@@ -27,11 +26,22 @@
 
             endpoint () {
                 return `/questions/${this.id}/favorites`
+            },
+
+            signedIn() {
+                return window.Auth.signedIn;
             }
         },
 
         methods: {
             toggle () {
+                if (! this.signedIn) {
+                    this.$toast.warning('Please login to favorite this question', 'Warning', {
+                        timeout: 3000,
+                        position: 'bottomLeft'
+                    });
+                    return;
+                }
                 this.isFavorited ? this.destroy() : this.create();
             },
 

--- a/resources/js/components/Favorite.vue
+++ b/resources/js/components/Favorite.vue
@@ -1,0 +1,28 @@
+<template>
+    <a title="Click to mark as favorite question (Click again to undo)" :class="classes">
+        <i class="fas fa-star fa-2x"></i>
+        <span class="favorites-count">{{ count }}</span>
+    </a>
+</template>
+<script>
+    export default {
+        props: ['question'],
+
+        data () {
+            return {
+                isFavorited: this.question.is_favorited,
+                count: this.question.favorites_count,
+                signedIn: true, // あとで修正する
+            }
+        },
+
+        computed: {
+            classes () {
+                return [
+                   'favorite', 'mt-3',
+                    ! this.signedIn ? 'off' : (this.isFavorited ? 'favorited' : '')
+                ];
+            }
+        }
+    }
+</script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,9 +9,6 @@
 
     <title>{{ config('app.name', 'Laravel') }}</title>
 
-    <!-- Scripts -->
-    <script src="{{ asset('js/app.js') }}" defer></script>
-
     <!-- Fonts -->
     <link rel="dns-prefetch" href="//fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
@@ -76,5 +73,13 @@
             @yield('content')
         </main>
     </div>
+    <!-- Scripts -->
+    <script>
+        window.Auth = {!! json_encode([
+            'signedIn' => Auth::check(),
+            'user' => Auth::user()
+        ]) !!}
+    </script>
+    <script src="{{ asset('js/app.js') }}" defer></script>
 </body>
 </html>

--- a/resources/views/shared/_favorite.blade.php
+++ b/resources/views/shared/_favorite.blade.php
@@ -1,10 +1,3 @@
-<a title="Click to mark as favorite question (Click again to undo)"
-   class="favorite mt-3 {{ Auth::guest() ? 'off' : ($model->is_favorited ? 'favorited' : '') }}"
-   onclick="event.preventDefault(); document.getElementById('favorite-question-{{ $model->id }}').submit();"
->
-    <i class="fas fa-star fa-2x"></i>
-    <span class="favorites-count">{{ $model->favorites_count }}</span>
-</a>
 <form action="/questions/{{ $model->id }}/favorites" id="favorite-question-{{ $model->id }}" method="POST" style="display:none;">
     @csrf
     @if ($model->is_favorited)

--- a/resources/views/shared/_favorite.blade.php
+++ b/resources/views/shared/_favorite.blade.php
@@ -1,6 +1,0 @@
-<form action="/questions/{{ $model->id }}/favorites" id="favorite-question-{{ $model->id }}" method="POST" style="display:none;">
-    @csrf
-    @if ($model->is_favorited)
-        @method('DELETE')
-    @endif
-</form>

--- a/resources/views/shared/_vote.blade.php
+++ b/resources/views/shared/_vote.blade.php
@@ -41,9 +41,7 @@
     </form>
     @if ($model instanceof App\Question)
         {{-- Favoriteボタン --}}
-        @include ('shared._favorite', [
-            'model' => $model,
-        ])
+        <favorite :question="{{ $model }}"></favorite>
     @elseif ($model instanceof App\Answer)
         {{-- Acceptボタン --}}
         @include ('shared._accept', [


### PR DESCRIPTION
## 概要
favoriteパーツをVue.jsのfavoriteコンポーネントにリプレイスしたい。

## 要件
・ログインユーザーのみfavoriteすることができる。非ログインユーザーがfavoriteした場合はwarningメッセージを表示する。
・機能要件自体は既存の要件と同じだが、サーバーとの通信はajaxで行う。

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

