### PR TITLE
answer読み込み機能の実装

### DIFF
--- a/app/Http/Controllers/AnswersController.php
+++ b/app/Http/Controllers/AnswersController.php
@@ -9,6 +9,21 @@ use Illuminate\Support\Facades\Auth;
 
 class AnswersController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth')->except('index');
+    }
+
+    /**
+     * answerの一覧を取得
+     *
+     * @param Question $question
+     */
+    public function index(Question $question)
+    {
+        return $question->answers()->with('user')->simplePaginate(3);
+    }
+
     /**
      * Store a newly created resource in storage.
      *

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -32,7 +32,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot()
     {
         Route::bind('slug', function($slug) {
-            return Question::with(['user', 'answers.user'])->where('slug', $slug)->first() ?? abort(404);
+            return Question::with('user')->where('slug', $slug)->first() ?? abort(404);
         });
 
         parent::boot();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2087,6 +2087,21 @@ __webpack_require__.r(__webpack_exports__);
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _Answer_vue__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Answer.vue */ "./resources/js/components/Answer.vue");
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+//
+//
+//
 //
 //
 //
@@ -2105,7 +2120,33 @@ __webpack_require__.r(__webpack_exports__);
 //
 
 /* harmony default export */ __webpack_exports__["default"] = ({
-  props: ['answers', 'count'],
+  props: ['question'],
+  data: function data() {
+    return {
+      questionId: this.question.id,
+      count: this.question.answers_count,
+      answers: [],
+      nextUrl: null
+    };
+  },
+  methods: {
+    fetch: function fetch(endpoint) {
+      var _this = this;
+
+      axios.get(endpoint).then(function (_ref) {
+        var _this$answers;
+
+        var data = _ref.data;
+
+        (_this$answers = _this.answers).push.apply(_this$answers, _toConsumableArray(data.data));
+
+        _this.nextUrl = data.next_page_url;
+      });
+    }
+  },
+  created: function created() {
+    this.fetch("/questions/".concat(this.questionId, "/answers"));
+  },
   computed: {
     title: function title() {
       return this.count + " " + (this.count > 1 ? 'Answers' : 'Answer');
@@ -38772,7 +38813,25 @@ var render = function() {
                     key: answer.id,
                     attrs: { answer: answer }
                   })
-                })
+                }),
+                _vm._v(" "),
+                _vm.nextUrl
+                  ? _c("div", { staticClass: "text-center mt-3" }, [
+                      _c(
+                        "button",
+                        {
+                          staticClass: "btn btn-outline-secondary",
+                          on: {
+                            click: function($event) {
+                              $event.preventDefault()
+                              return _vm.fetch(_vm.nextUrl)
+                            }
+                          }
+                        },
+                        [_vm._v("Load more answers")]
+                      )
+                    ])
+                  : _vm._e()
               ],
               2
             )

--- a/resources/js/components/Answers.vue
+++ b/resources/js/components/Answers.vue
@@ -8,6 +8,9 @@
                     </div>
                     <hr>
                     <answer v-for="answer in answers" :answer="answer" :key="answer.id"></answer>
+                    <div v-if="nextUrl" class="text-center mt-3">
+                        <button @click.prevent="fetch(nextUrl)" class="btn btn-outline-secondary">Load more answers</button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -17,7 +20,30 @@
 <script>
     import Answer from './Answer.vue';
     export default {
-        props: ['answers', 'count'],
+        props: ['question'],
+
+        data () {
+            return {
+                questionId: this.question.id,
+                count: this.question.answers_count,
+                answers: [],
+                nextUrl: null,
+            }
+        },
+
+        methods: {
+            fetch (endpoint) {
+                axios.get(endpoint)
+                .then(({ data }) => {
+                    this.answers.push(...data.data);
+                    this.nextUrl = data.next_page_url;
+                });
+            }
+        },
+
+        created () {
+            this.fetch(`/questions/${this.questionId}/answers`);
+        },
 
         computed: {
             title () {

--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -32,7 +32,7 @@
                 </div>
             </div>
         </div>
-        <answers :answers="{{ $question->answers }}" :count="{{ $question->answers_count }}"></answers>
+        <answers :question="{{ $question }}"></answers>
         @include('answers._create')
     </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ Route::get('/home', 'HomeController@index')->name('home');
 
 Route::resource('questions', 'QuestionsController')->except('show');
 Route::post('/questions/{question}/answers', 'AnswersController@store')->name('answers.store');
+Route::get('/questions/{question}/answers', 'AnswersController@index')->name('answers.index');
 Route::get('/questions/{question}/answers/{answer}/edit', 'AnswersController@edit')->name('answers.edit');
 Route::patch('/questions/{question}/answers/{answer}', 'AnswersController@update')->name('answers.update');
 Route::delete('/questions/{question}/answers/{answer}', 'AnswersController@destroy')->name('answers.destroy');


### PR DESCRIPTION
## 概要・要件
既存の仕様では、一度に全てのanswerを読み込んで一覧表示させている。
しかしながら、それでは全てのanswerを読み込み表示するのに時間がかかってしまいユーザー待機時間が長くなってしまう。
そこで、1度目のローディングではanswerを3件のみ表示して「さらに表示」ボタンを押下したら、他のanswerを表示できるようにしたい。また実装はvueのcomponentで実装し、サーバとの通信はajaxでの更新とする。

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

