### PR TITLE
acceptボタンを押下した際の処理の修正

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1908,6 +1908,7 @@ module.exports = {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _event_bus__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../event-bus */ "./resources/js/event-bus.js");
 //
 //
 //
@@ -1919,6 +1920,7 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: ['answer'],
   data: function data() {
@@ -1927,17 +1929,25 @@ __webpack_require__.r(__webpack_exports__);
       id: this.answer.id
     };
   },
+  created: function created() {
+    var _this = this;
+
+    _event_bus__WEBPACK_IMPORTED_MODULE_0__["default"].$on('accepted', function (id) {
+      _this.isBest = id === _this.id;
+    });
+  },
   methods: {
     create: function create() {
-      var _this = this;
+      var _this2 = this;
 
       axios.post("/answers/".concat(this.id, "/accept")).then(function (res) {
-        _this.$toast.success(res.data.message, 'success', {
+        _this2.$toast.success(res.data.message, 'success', {
           timeout: 3000,
           position: 'bottomLeft'
         });
 
-        _this.isBest = true;
+        _this2.isBest = true;
+        _event_bus__WEBPACK_IMPORTED_MODULE_0__["default"].$emit('accepted', _this2.id);
       });
     }
   },
@@ -51725,6 +51735,23 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Vote_vue_vue_type_template_id_40e744d5___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
+
+/***/ }),
+
+/***/ "./resources/js/event-bus.js":
+/*!***********************************!*\
+  !*** ./resources/js/event-bus.js ***!
+  \***********************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var vue__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! vue */ "./node_modules/vue/dist/vue.common.js");
+/* harmony import */ var vue__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(vue__WEBPACK_IMPORTED_MODULE_0__);
+
+var eventBus = new vue__WEBPACK_IMPORTED_MODULE_0___default.a();
+/* harmony default export */ __webpack_exports__["default"] = (eventBus);
 
 /***/ }),
 

--- a/resources/js/components/Accept.vue
+++ b/resources/js/components/Accept.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script>
+    import EventBus from '../event-bus';
     export default {
         props: ['answer'],
 
@@ -18,6 +19,12 @@
                 isBest: this.answer.is_best,
                 id: this.answer.id,
             }
+        },
+
+        created () {
+            EventBus.$on('accepted', id => {
+                this.isBest = id === this.id;
+            })
         },
 
         methods: {
@@ -29,6 +36,8 @@
                         position: 'bottomLeft',
                     });
                     this.isBest = true;
+
+                    EventBus.$emit('accepted', this.id);
                 })
             }
         },

--- a/resources/js/event-bus.js
+++ b/resources/js/event-bus.js
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+
+const eventBus = new Vue();
+
+export default eventBus;


### PR DESCRIPTION
## 概要
既存の仕様だと、answer1がベストアンサーに選出されている状態で、answer2をベストアンサーに選出すると、answer1とanswer2の両方がベストアンサーに選出されている状態となり、画面更新をするとanswer2がベストアンサーに選出された状態になる。そのため、ベストアンサーに選出した際にリアクティブにUIが変更されるように修正したい。

## 要件
acceptボタンを押下したらajax処理でサーバーとの通信を行うように修正する。

## PRマージまでのチェックリスト
- [ ] merge準備完了
  - [ ] レビュー済みタグが付いている
  - [ ] この項目以外のチェックボックス全てにチェックが入っている
  - [ ] conflictが発生していない
  - [ ] 最新の親ブランチでrebaseが完了している
  - [ ] mergeしても良いタイミングである

