### PR TITLE
AcceptAnswer機能とFavorites機能のAPIエンドポイント実装

### DIFF
--- a/app/Http/Controllers/Api/AcceptAnswerController.php
+++ b/app/Http/Controllers/Api/AcceptAnswerController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Answer;
+
+class AcceptAnswerController extends Controller
+{
+    public function __invoke(Answer $answer)
+    {
+        $this->authorize('accept', $answer);
+
+        $answer->question->acceptBestAnswer($answer);
+
+        return response()->json([
+            'message' => "You have accepted this answer as best answer"
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/FavoritesController.php
+++ b/app/Http/Controllers/Api/FavoritesController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Question;
+
+class FavoritesController extends Controller
+{
+    public function store(Question $question)
+    {
+        $question->favorites()->attach(auth()->id());
+
+        return response()->json(null, 204);
+    }
+
+    public function destroy(Question $question)
+    {
+        $question->favorites()->detach(auth()->id());
+
+        return response()->json(null, 204);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,9 @@ Route::get('/questions/{question}-{slug}', 'Api\QuestionDetailsController');
 Route::middleware(['auth:api'])->group(function() {
     Route::apiResource('/questions', 'Api\QuestionsController');
     Route::apiResource('/questions.answers', 'Api\AnswersController')->except('index');
+    Route::post('/answers/{answer}/accept', 'Api\AcceptAnswerController');
+    Route::post('/questions/{question}/favorites', 'Api\FavoritesController@store');
+    Route::delete('/questions/{question}/favorites', 'Api\FavoritesController@destroy');
 });
 
 Route::middleware('auth:api')->get('/user', function (Request $request) {


### PR DESCRIPTION
## 概要
既存のAcceptAnswer機能とFavorites機能をAPIにてリプレイスを行う

## 要件
仕様はこれまでの機能と同様とする

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

