### PR TITLE
deleteボタンが非表示にならない障害の修正

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2366,6 +2366,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _Answer_vue__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Answer.vue */ "./resources/js/components/Answer.vue");
 /* harmony import */ var _NewAnswer_vue__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./NewAnswer.vue */ "./resources/js/components/NewAnswer.vue");
 /* harmony import */ var _mixins_highlight__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../mixins/highlight */ "./resources/js/mixins/highlight.js");
+/* harmony import */ var _event_bus__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../event-bus */ "./resources/js/event-bus.js");
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
 
 function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -2403,6 +2404,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 
 
 
+
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: ['question'],
   mixins: [_mixins_highlight__WEBPACK_IMPORTED_MODULE_2__["default"]],
@@ -2424,6 +2426,10 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       this.$nextTick(function () {
         _this.highlight("answer-".concat(answer.id));
       });
+
+      if (this.count === 1) {
+        _event_bus__WEBPACK_IMPORTED_MODULE_3__["default"].$emit('answers-count-changed', this.count);
+      }
     },
     fetch: function fetch(endpoint) {
       var _this2 = this;
@@ -2449,6 +2455,10 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
     remove: function remove(index) {
       this.answers.splice(index, 1);
       this.count--;
+
+      if (this.count === 0) {
+        _event_bus__WEBPACK_IMPORTED_MODULE_3__["default"].$emit('answers-count-changed', this.count);
+      }
     }
   },
   created: function created() {
@@ -2743,6 +2753,7 @@ __webpack_require__.r(__webpack_exports__);
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _mixins_modification_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../mixins/modification.js */ "./resources/js/mixins/modification.js");
+/* harmony import */ var _event_bus__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../event-bus */ "./resources/js/event-bus.js");
 //
 //
 //
@@ -2801,9 +2812,17 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 
+
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: ['question'],
   mixins: [_mixins_modification_js__WEBPACK_IMPORTED_MODULE_0__["default"]],
+  mounted: function mounted() {
+    var _this = this;
+
+    _event_bus__WEBPACK_IMPORTED_MODULE_1__["default"].$on('answers-count-changed', function (count) {
+      _this.question.answers_count = count;
+    });
+  },
   data: function data() {
     return {
       title: this.question.title,
@@ -2842,18 +2861,19 @@ __webpack_require__.r(__webpack_exports__);
       };
     },
     "delete": function _delete() {
-      var _this = this;
+      var _this2 = this;
 
       axios["delete"](this.endpoint).then(function (_ref) {
         var data = _ref.data;
 
-        _this.$toast.success(data.message, "Success", {
+        _this2.$toast.success(data.message, "Success", {
           timeout: 2000
         });
+
+        _this2.$router.push({
+          name: 'questions'
+        });
       });
-      setTimeout(function () {
-        window.location.href = "/questions";
-      }, 3000);
     }
   }
 });

--- a/resources/js/components/Answers.vue
+++ b/resources/js/components/Answers.vue
@@ -24,6 +24,7 @@
     import Answer from './Answer.vue';
     import NewAnswer from './NewAnswer.vue';
     import highlight from "../mixins/highlight";
+    import EventBus from '../event-bus';
     export default {
         props: ['question'],
         mixins: [highlight],
@@ -44,6 +45,9 @@
                 this.$nextTick(() => {
                     this.highlight(`answer-${answer.id}`);
                 })
+                if (this.count === 1) {
+                    EventBus.$emit('answers-count-changed', this.count);
+                }
             },
             fetch (endpoint) {
                 this.answerIds = [];
@@ -63,6 +67,9 @@
             remove (index) {
                 this.answers.splice(index, 1);
                 this.count--;
+                if (this.count === 0) {
+                    EventBus.$emit('answers-count-changed', this.count);
+                }
             }
         },
 

--- a/resources/js/components/Question.vue
+++ b/resources/js/components/Question.vue
@@ -57,9 +57,15 @@
 </template>
 <script>
     import modification from '../mixins/modification.js';
+    import EventBus from '../event-bus';
     export default {
         props: ['question'],
         mixins: [modification],
+        mounted () {
+            EventBus.$on('answers-count-changed', (count) => {
+                this.question.answers_count = count;
+            })
+        },
         data () {
             return {
                 title: this.question.title,
@@ -99,12 +105,10 @@
             },
             delete () {
                 axios.delete(this.endpoint)
-                    .then(({ data }) => {
+                    .then(({data}) => {
                         this.$toast.success(data.message, "Success", { timeout: 2000 });
+                        this.$router.push({ name: 'questions' });
                     });
-                setTimeout(() => {
-                    window.location.href = "/questions";
-                }, 3000);
             }
         }
     }


### PR DESCRIPTION
## 概要
Answerを投稿した際に、Questionの`Delete`ボタンが画面のリロードするまで削除されずに残っているので、
Answerを投稿した際に`Delete`ボタンが非表示になるようにする。

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

