### PR TITLE
Answer読み込み時の重複を除去

### DIFF
--- a/app/Http/Controllers/Api/AnswersController.php
+++ b/app/Http/Controllers/Api/AnswersController.php
@@ -18,9 +18,13 @@ class AnswersController extends Controller
      */
     public function index(Question $question)
     {
-        $answer = $question->answers()->with('user')->simplePaginate(3);
+        $answers = $question->answers()->with('user')->where(function ($q) {
+            if (request()->has('excludes')) {
+                $q->whereNotIn('id', request()->query('excludes'));
+            }
+        })->simplePaginate(3);
 
-        return AnswerResource::collection($answer);
+        return AnswerResource::collection($answers);
     }
 
     /**

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2414,13 +2414,15 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       count: this.question.answers_count,
       answers: [],
       answerIds: [],
-      nextUrl: null
+      nextUrl: null,
+      excludeAnswers: []
     };
   },
   methods: {
     add: function add(answer) {
       var _this = this;
 
+      this.excludeAnswers.push(answer);
       this.answers.push(answer);
       this.count++;
       this.$nextTick(function () {
@@ -2467,6 +2469,15 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
   computed: {
     title: function title() {
       return this.count + " " + (this.count > 1 ? 'Answers' : 'Answer');
+    },
+    theNextUrl: function theNextUrl() {
+      if (this.nextUrl && this.excludeAnswers.length) {
+        return this.nextUrl + this.excludeAnswers.map(function (a) {
+          return '&excludes[]=' + a.id;
+        }).join('');
+      }
+
+      return this.nextUrl;
     }
   },
   components: {
@@ -56041,7 +56052,7 @@ var render = function() {
                       })
                     }),
                     _vm._v(" "),
-                    _vm.nextUrl
+                    _vm.theNextUrl
                       ? _c("div", { staticClass: "text-center mt-3" }, [
                           _c(
                             "button",
@@ -56050,7 +56061,7 @@ var render = function() {
                               on: {
                                 click: function($event) {
                                   $event.preventDefault()
-                                  return _vm.fetch(_vm.nextUrl)
+                                  return _vm.fetch(_vm.theNextUrl)
                                 }
                               }
                             },

--- a/resources/js/components/Answers.vue
+++ b/resources/js/components/Answers.vue
@@ -9,8 +9,8 @@
                         </div>
                         <hr>
                         <answer @deleted="remove(index)" v-for="(answer, index) in answers" :answer="answer" :key="answer.id"></answer>
-                        <div v-if="nextUrl" class="text-center mt-3">
-                            <button @click.prevent="fetch(nextUrl)" class="btn btn-outline-secondary">Load more answers</button>
+                        <div class="text-center mt-3" v-if="theNextUrl">
+                            <button @click.prevent="fetch(theNextUrl)" class="btn btn-outline-secondary">Load more answers</button>
                         </div>
                     </div>
                 </div>
@@ -35,11 +35,13 @@
                 answers: [],
                 answerIds: [],
                 nextUrl: null,
+                excludeAnswers: [],
             }
         },
 
         methods: {
             add (answer) {
+                this.excludeAnswers.push(answer);
                 this.answers.push(answer);
                 this.count++;
                 this.$nextTick(() => {
@@ -80,6 +82,13 @@
         computed: {
             title () {
                 return this.count + " " + (this.count > 1 ? 'Answers' : 'Answer');
+            },
+            theNextUrl () {
+                if (this.nextUrl && this.excludeAnswers.length) {
+                    return this.nextUrl +
+                        this.excludeAnswers.map(a => '&excludes[]=' + a.id).join('');
+                }
+                return this.nextUrl;
             }
         },
 


### PR DESCRIPTION
## 概要
Answer投稿し、「Load More Answers」ボタンを押下すると投稿したAnswerが重複して表示されるため、重複を除去したい。

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

