### PR TITLE
未ログイン時にQuestionが取得できない障害の対応

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -23,7 +23,6 @@ Route::get('/questions/{question}/answers', 'Api\AnswersController@index');
 Route::get('/questions/{question}-{slug}', 'Api\QuestionDetailsController');
 
 Route::middleware(['auth:api'])->group(function() {
-    Route::apiResource('/questions', 'Api\QuestionsController');
     Route::apiResource('/questions.answers', 'Api\AnswersController')->except('index');
     Route::post('/answers/{answer}/accept', 'Api\AcceptAnswerController');
     Route::post('/questions/{question}/vote', 'Api\VoteQuestionController');


### PR DESCRIPTION
## 概要
未ログイン時にQuestionが取得できないためその調査対応を行う。

## 要件
consoleに下記のエラーメッセージが出力されている。
```
Failed to load resource: the server responded with a status of 401 (Unauthorized)
app.js:992 Uncaught (in promise) Error: Request failed with status code 401
    at createError (app.js:992)
    at settle (app.js:1253)
    at XMLHttpRequest.handleLoad (app.js:461)
```

## 原因
同一のapiルーティングがログイン時と未ログイン時の両方で定義されていたため。

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] レビュー済みタグが付いている
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである

